### PR TITLE
Set up Cursor Cloud dev environment for CPython

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# AGENTS.md
+
+This repository is **CPython** — the reference implementation of the Python
+programming language (currently `3.15.0a8+`). It is a C interpreter plus the
+Python standard library (`Lib/`) and documentation (`Doc/`). There are **no
+runtime services, databases, or web servers**: "running the app" means building
+the `./python` interpreter, and "end-to-end testing" means running the
+regression test suite under `Lib/test/`.
+
+Canonical developer instructions live in `README.rst` (section "Build
+Instructions") and `.devcontainer/devcontainer.json`. Prefer those; the notes
+below only capture non-obvious, durable context for working in the Cursor Cloud
+environment.
+
+## Cursor Cloud specific instructions
+
+- **Build output location:** A successful `make` produces the interpreter at the
+  repo root as `./python` (note: no `.exe` on Linux; only macOS produces
+  `./python.exe`). Always invoke the freshly built interpreter as `./python`,
+  never the system `python3` (which is 3.12 and unrelated to your changes).
+- **Dev build flags:** Use a debug build for development:
+  `./configure --config-cache --with-pydebug && make -s -j$(nproc)`. The update
+  script already runs this on startup, so on a fresh VM `./python` is normally
+  already built. After editing C sources, re-run `make -s -j$(nproc)`
+  (incremental, fast). Editing pure-Python files under `Lib/` needs no rebuild.
+- **`_decimal` module is expected to be missing** in this environment
+  (`libmpdec` dev headers are not available from apt). The build still succeeds
+  and `_decimal`/`test_decimal` simply won't be available. This is not an error.
+- **System build dependencies** (installed once into the VM snapshot, not by the
+  update script since they need `sudo`): `build-essential gdb pkg-config
+  libbz2-dev libffi-dev libgdbm-dev libgdbm-compat-dev liblzma-dev
+  libncurses5-dev libreadline6-dev libsqlite3-dev libssl-dev tk-dev uuid-dev
+  zlib1g-dev libzstd-dev`. If a stdlib C-extension module is unexpectedly
+  missing, install its `-dev` package and re-run `./configure` + `make`.
+- **Running tests:** `./python -m test [names]` (add `-j$(nproc)` for
+  parallelism, `-v` for verbose). `make test` runs the full suite and is slow;
+  prefer naming specific test modules, e.g.
+  `./python -m test -j4 test_grammar test_os test_json`. Tests for optional
+  modules whose libs are absent are skipped, not failed.
+- **Linting** uses `ruff` (pinned to the version in `.pre-commit-config.yaml`).
+  It is installed via `pip --user`, so it lives at `~/.local/bin/ruff`; ensure
+  `~/.local/bin` is on `PATH`. Ruff only targets specific subtrees
+  (`Lib/test/`, `Doc/`, `Tools/*`, `Platforms/*`) as configured in
+  `.pre-commit-config.yaml`, not the whole repo. A `warning: Support for Python
+  3.15 is under development` line from ruff is expected and harmless.
+- **Docs** (optional) build with `make --directory Doc venv html`; not required
+  for interpreter development.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this CPython checkout and documents non-obvious startup/run caveats for future Cloud agents.

This repo is the **CPython interpreter** (`3.15.0a8+`) — there are no runtime services/databases. "Running the app" = building `./python`; "end-to-end testing" = running the `Lib/test/` regression suite.

### Changes
- Add `AGENTS.md` with a `## Cursor Cloud specific instructions` section (build flags, output location, expected missing `_decimal`, test/lint commands, system dep list).

### Environment setup (via update script, not committed to repo)
```
./configure --config-cache --with-pydebug
make -s -j$(nproc)
python3 -m pip install --user --quiet "ruff==0.15.7"
```
System build deps (`libssl-dev`, `libsqlite3-dev`, `libffi-dev`, `zlib1g-dev`, etc.) were installed into the VM once.

## Testing
- ✅ `./configure --config-cache --with-pydebug` — configured (all optional modules detected except `_decimal`)
- ✅ `make -s -j$(nproc)` — built `./python` (`Python 3.15.0a8+`)
- ✅ `./python -m test -j4 test_grammar test_builtin test_os test_sqlite3 test_hashlib test_json` — 7 tests OK, 1,597 subtests
- ✅ `ruff check Lib/test/test_json` — All checks passed
- ✅ hello-world exercising `hashlib`/`zlib`/`ssl`/`sqlite3` against the freshly built interpreter

[hello_world_output.log](https://cursor.com/agents/bc-03103f3d-d154-413b-95a2-25266cf2b63c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_output.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-03103f3d-d154-413b-95a2-25266cf2b63c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-03103f3d-d154-413b-95a2-25266cf2b63c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

